### PR TITLE
Travis ci and clang fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ script:
     - mkdir build && cd build
     - cmake -DCMAKE_BUILD_TYPE=Debug ..
     - make
-    - make test
+    - ctest -V
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+language: generic
+
+dist: trusty
+sudo: required
+
+cache:
+    apt: true
+
+matrix:
+    include:
+    - env: CXX=g++-6 CC=gcc-6
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources: &sources
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise
+            - llvm-toolchain-precise-3.8
+            - llvm-toolchain-precise-3.7
+            - llvm-toolchain-precise-3.6
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main'
+              key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
+    - env: CXX=g++-5 CC=gcc-5
+      addons:
+        apt:
+          packages:
+            - g++-5
+          sources: *sources
+    - env: CXX=clang++-3.9 CC=clang-3.9
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+            - libc++-dev
+          sources: *sources
+    - env: CXX=clang++-3.8 CC=clang-3.8
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+            - libc++-dev
+          sources: *sources
+    - env: CXX=clang++-3.7 CC=clang-3.7
+      addons:
+        apt:
+          packages:
+            - clang-3.7
+            - libc++-dev
+          sources: *sources
+    - env: CXX=clang++-3.6 CC=clang-3.6
+      addons:
+        apt:
+          packages:
+            - clang-3.6
+            - libc++-dev
+          sources: *sources
+
+script:
+    - if [[ "$CXX" == clang* ]]; then export CXXFLAGS="-stdlib=libc++"; fi
+    - mkdir build && cd build
+    - cmake -DCMAKE_BUILD_TYPE=Debug ..
+    - make
+    - make test
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,3 @@ script:
     - make
     - make test
 
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(observable)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0)
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/tests/src/property.cpp
+++ b/tests/src/property.cpp
@@ -87,7 +87,7 @@ TEST_F(property_test, setting_same_value_does_not_trigger_subscribers)
 TEST_F(property_test, copy_constructed_property_has_correct_value)
 {
     property<int> p { 123 };
-    auto c { p };
+    auto c = p;
 
     ASSERT_EQ(c.value(), 123);
 }
@@ -107,7 +107,7 @@ TEST_F(property_test, copy_constructed_property_has_no_subscribers)
     property<int, property_test> p { 123 };
     p.subscribe([&]() { ++call_count; }).release();
 
-    auto c { p };
+    auto c = p;
     set(c, 1234);
 
     ASSERT_EQ(call_count, 0);
@@ -129,7 +129,7 @@ TEST_F(property_test, copy_assigned_property_has_no_subscribers)
 TEST_F(property_test, move_constructed_property_has_correct_value)
 {
     property<std::unique_ptr<int>> p { std::make_unique<int>(123) };
-    auto c { std::move(p) };
+    auto c = std::move(p);
 
     ASSERT_EQ(*c.value(), 123);
 }
@@ -149,7 +149,7 @@ TEST_F(property_test, move_constructed_property_keeps_subscribers)
     property<std::unique_ptr<int>, property_test> p { std::make_unique<int>(123) };
     p.subscribe([&]() { ++call_count; }).release();
 
-    auto c { std::move(p) };
+    auto c = std::move(p);
     set(c, std::make_unique<int>(1234));
 
     ASSERT_EQ(call_count, 1);


### PR DESCRIPTION
Adds **Travis CI** with following builds:

- Gcc 6
- Gcc 5
- Clang 3.9
- Clang 3.8
- Clang 3.7
- Clang 3.6

Each building ***Debug*** configuration and running **Unittests**. For **compatibility** reasons, the minimum **Cmake** version required has been set to ***v3.0*** (Travis has v3.2 installed by default).

There are some small **fixes** for **Clang 3.6** and **3.7**, because building with these compilers fails otherwise.


```
[…]/tests/src/property.cpp:90:12: error: direct
      list initialization of a variable with a deduced type will change meaning
      in a future version of Clang; insert an '=' to avoid a change in behavior
      [-Werror,-Wfuture-compat]
    auto c { p };
           ^
           =
```