### PR TITLE
feature/clion_gitignore_rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
+.idea/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Visual Studio Code
 .vscode/
+
+# CLion/IDEA
 .idea/
+
+# The default out of source build folder
 build/


### PR DESCRIPTION
First of all I hope I created this pull request correctly :).

Now to the point. This commit adds ignore rule for the `.idea/` folder.
This folder is the project folder generated by CLion/IDEA C++ IDE. I'm using this IDE because it works directly with CMake projects and it is cross platform.

This pull request is a precursor to the **future/combinable**, where I will work on the **observable::combinable<>()** method we talked about here: [ddinu/observable@4406da6bed](https://github.com/ddinu/observable/commit/4406da6bed34ade089ea007ac9b3945ed956ef05#commitcomment-19827841).