### PR TITLE
Add template version of adapt filter

### DIFF
--- a/observable/include/observable/expressions/filters.hpp
+++ b/observable/include/observable/expressions/filters.hpp
@@ -31,6 +31,31 @@ inline auto NAME(Args && ... args) \
     return ::observable::expr::expr_detail::make_node(OP, std::forward<Args>(args) ...); \
 }
 
+//! Create an expression filter from a callable.
+//!
+//! Expression filters take expression nodes as arguments and return an expression
+//! node.
+//!
+//! This macro wraps a regular callable (i.e. one that does not work with
+//! expression nodes) and turns it into an expression filter.
+//!
+//! \param NAME The name that will be used for the expression filter. This must
+//!             be a valid function identifier.
+//! \param OP Callable instance that will be converted to an expression filter.
+//!           This instance must be copy-constructible.
+//! \tparam T The type parameter for the expression filter.
+//!
+//! \ingroup observable_expressions
+#define OBSERVABLE_ADAPT_FILTER_TEMPLATE(NAME, OP) \
+template <typename T, typename ... Args> \
+inline auto NAME(Args && ... args) \
+                -> std::enable_if_t< \
+                        ::observable::expr::expr_detail::are_any_observable<Args ...>::value, \
+                        ::observable::expr::expr_detail::result_node_t<decltype(OP<T>), Args ...>> \
+{ \
+    return ::observable::expr::expr_detail::make_node(OP<T>, std::forward<Args>(args) ...); \
+}
+
 namespace observable { inline namespace expr {
 
 //! \cond

--- a/tests/src/expressions/filters.cpp
+++ b/tests/src/expressions/filters.cpp
@@ -66,6 +66,61 @@ TEST_CASE("filter/adapter_filter", "[filter]")
     }
 }
 
+template<typename T>
+T test_filter_template_(int a) { return static_cast<T>(a) / 2; }
+OBSERVABLE_ADAPT_FILTER_TEMPLATE(test_filter_template, test_filter_template_)
+
+TEST_CASE("filter/adapter_filter_template", "[filter]")
+{
+    SECTION("adapter_filter_template computes initial value")
+    {
+        auto val = value<int> { 5 };
+        auto res = observe(test_filter_template<float>(val));
+
+        REQUIRE(res.get() == 2.5f);
+    }
+
+    SECTION("adapter_filter_template recomputes value")
+    {
+        auto val = value<int> { 5 };
+        auto res = observe(test_filter_template<float>(val));
+
+        val = 7;
+
+        REQUIRE(res.get() == 3.5f);
+    }
+
+    SECTION("adapter_filter_template can take expression parameters")
+    {
+        auto a = value<int> { 1 };
+        auto b = value<int> { 2 };
+
+        auto res = observe(test_filter_template<float>(a + b));
+
+        REQUIRE(res.get() == static_cast<float>(1 + 2) / 2);
+
+        a = 2;
+        b = 3;
+
+        REQUIRE(res.get() == static_cast<float>(2 + 3) / 2);
+    }
+
+    SECTION("adapter_filter_template can participate in expression")
+    {
+        auto a = value<int> { 1 };
+        auto b = value<int> { 3 };
+
+        auto res = observe(a + test_filter_template<float>(b) * 20);
+
+        REQUIRE(res.get() == 1 + (3.0f / 2) * 20);
+
+        a = 2;
+        b = 3;
+
+        REQUIRE(res.get() == 2 + (3.0f / 2) * 20);
+    }
+}
+
 TEST_CASE("filter/select", "[filter]")
 {
     auto p = value<bool> { true };


### PR DESCRIPTION
My usecase was a stream of different json that should be deserialized into correct struct.

It only supports one type param. I'm new to c++ so maybe there's a way to make number of type params more flexible.

Simple usage below.

```
#include <iostream>
#include <observable/observable.hpp>

observable::value<int> value(5);

template<typename T>
static T convert_(const int &val) {
    return static_cast<T>(val);
}
OBSERVABLE_ADAPT_FILTER_TEMPLATE(convert, convert_)

template<typename T>
observable::value<T> convertedValue() {
    return observable::observe(convert<T>(value));
}

int main() {
    auto convertInt = convertedValue<int>();
    convertInt.subscribe_and_call([](const auto i) {
        std::cout << "Half Int: " << i / 2 << std::endl;
    });

    auto convertFloat = convertedValue<float>();
    convertFloat.subscribe_and_call([](const auto i) {
        std::cout << "Half Float: " << i / 2 << std::endl;
    });

    int input{};
    while (true) {
        std::cin >> input;
        value.set(input);
    }
}
```